### PR TITLE
Fix the publishing github actions config that publishes the library

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,23 +20,14 @@ jobs:
         env:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
         run: |
-          echo "$SIGNING_KEY" | base64 --decode | gpg --dearmor > ${HOME}/secring.gpg
+          brew install gpg
+          echo "$SIGNING_KEY" | gpg --dearmor > ${HOME}/secring.gpg
 
       - name: Setup Gradle
         uses: gradle/actions/setup-gradle@v4
 
-      - name: Add Gradle Properties
-        env:
-          MAVEN_CENTRAL_USERNAME: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          SIGNING_KEY_ID: ${{ secrets.SIGNING_KEY_ID }}
-          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
-        run: |
-          echo "mavenCentralUsername=${MAVEN_CENTRAL_USERNAME}" >> gradle.properties
-          echo "mavenCentralPassword=${MAVEN_CENTRAL_PASSWORD}" >> gradle.properties
-          echo "signing.keyId=${SIGNING_KEY_ID}" >> gradle.properties
-          echo "signing.password=${SIGNING_KEY_PASSWORD}" >> gradle.properties
-          echo "signing.secretKeyRingFile=${HOME}/secring.gpg" >> gradle.properties
+      - name: Make gradlew executable
+        run: chmod +x ./gradlew
 
       - name: Setup Xcode
         uses: maxim-lobanov/setup-xcode@v1
@@ -44,5 +35,10 @@ jobs:
           xcode-version: latest-stable
 
       - name: Publish To Maven Central
+        env:
+          ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}
+          ORG_GRADLE_PROJECT_mavenCentralPassword: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          SIGNING_KEY_PASSWORD: ${{ secrets.SIGNING_KEY_PASSWORD }}
         run: |
-          ./gradlew :contactpicker:publishToMavenCentral
+          ./gradlew :contactpicker:publishToMavenCentral -no-configuration-cache --info --stacktrace

--- a/contactpicker/build.gradle.kts
+++ b/contactpicker/build.gradle.kts
@@ -1,4 +1,7 @@
 import com.vanniktech.maven.publish.SonatypeHost
+import org.gradle.api.publish.maven.tasks.AbstractPublishToMaven
+import org.gradle.kotlin.dsl.withType
+import org.gradle.plugins.signing.Sign
 import org.jetbrains.kotlin.gradle.ExperimentalKotlinGradlePluginApi
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
@@ -8,6 +11,21 @@ plugins {
     alias(libs.plugins.jetbrainsCompose)
     alias(libs.plugins.compose.compiler)
     alias(libs.plugins.vanniktechMavenPublish)
+    id("signing")
+}
+
+signing {
+    useInMemoryPgpKeys(
+        System.getenv("SIGNING_KEY"),
+        System.getenv("SIGNING_KEY_PASSWORD")
+    )
+    sign(publishing.publications)
+
+    // Temporary workaround, see https://github.com/gradle/gradle/issues/26091#issuecomment-1722947958
+    tasks.withType<AbstractPublishToMaven>().configureEach {
+        val signingTasks = tasks.withType<Sign>()
+        mustRunAfter(signingTasks)
+    }
 }
 
 mavenPublishing {


### PR DESCRIPTION
- using in-memory pgp signing keys
- install gpg in the Configure GPG step (gpg is not pre-installed on macOs)
- make ./gradlew executable before calling ./gradlew